### PR TITLE
Corrected vertical padding for narrow views

### DIFF
--- a/gallary/css/responsive.css
+++ b/gallary/css/responsive.css
@@ -108,7 +108,7 @@
 	1. PRIMARY STYLES
 	--------------------------------- */
 
-	body{ font-size: 14px; margin: 0; padding: 60px 0; height: 100%; width: 100%; }
+	body{ font-size: 14px; margin: 0; padding: 60px 0 0 0; height: 100%; width: 100%; }
 	
 	
 	/* ---------------------------------


### PR DESCRIPTION
## Relevant Project Issue Numbers :hash:

resolve #19 

## Involved Project Members :bust_in_silhouette:

@logiclrd
 
## An Explanation of Your Changes :speech_balloon:

Updated the padding defined in `gallary/css/responsive.css` for views up to 575 px wide so that the vertical padding of 60px applies only to the top of the body.

## Any Screenshots of Your Changes :camera:
 
![image](https://user-images.githubusercontent.com/2349379/67517711-cc87e300-f668-11e9-89b5-d69785ab334a.png)
