### PR TITLE
CV and resume buttons are not align in mobile view

### DIFF
--- a/about-me.html
+++ b/about-me.html
@@ -177,11 +177,11 @@
         			<h2>Download Documents</h2>
         			<p>If you want my Resume or curriculum vitae click blow!</p>
         		</div>
-				<div class="button-group-area mt-40">
-					<a href="https://drive.google.com/open?id=1jhVaZfFA-IvgXUO6CCeFqLj5840V0eSr" target="_blank" class="genric-btn success circle arrow"> Download CV  &nbsp;&nbsp;<i class="fas fa-download" > </i></a>
+            <div class="button-group-area mt-40">
+              <a href="https://drive.google.com/open?id=1jhVaZfFA-IvgXUO6CCeFqLj5840V0eSr" target="_blank" class="genric-btn success circle arrow">Download CV<i class="fas fa-download" > </i></a>
 
-					<a href="https://drive.google.com/open?id=1vVY8iGEAa6dkzxhd04HllgNP4yjqQuGJ" target="_blank" class="genric-btn success circle arrow">Download Résumé &nbsp;&nbsp;<i class="fas fa-download"></i> </a>
-				</div>
+              <a href="https://drive.google.com/open?id=1vVY8iGEAa6dkzxhd04HllgNP4yjqQuGJ" target="_blank" class="genric-btn success circle arrow">Download Résumé<i class="fas fa-download"></i> </a>
+            </div>
         	</div>
         </section>
         <!--================End Testimonials Area =================-->

--- a/css/style.css
+++ b/css/style.css
@@ -1319,6 +1319,7 @@ button:focus {
   color: #222222; }
 
 .button-group-area {
+  text-align: center;
   margin-top: 15px; }
   .button-group-area:nth-child(odd) {
     margin-top: 40px; }
@@ -1340,6 +1341,9 @@ button:focus {
     cursor: not-allowed; }
     .button-group-area .disable:before {
       display: none; }
+  .button-group-area a i {
+    margin-left: 10px;
+  }
 
 .primary {
   background: #52c5fd; }
@@ -1562,7 +1566,6 @@ h6 {
   font-weight: 500;
   cursor: pointer;
   position: relative;
-  left: 380px;
   -webkit-transition: all 0.3s ease 0s;
   -moz-transition: all 0.3s ease 0s;
   -o-transition: all 0.3s ease 0s;


### PR DESCRIPTION
closes #10 

replaces fake spaces with margin
properly centers about-me page CV buttons on all screen sizes

Please provide the following information where possible to help the pull request reviewer merge your PR quicker!


## Involved Project Members :bust_in_silhouette:

@jpbelo
 
## An Explanation of Your Changes :speech_balloon:

Spacing between text and icon:
- replaces `&nbsp;` for margin-left on the icon

Center alignment of the buttons on the page:
- removes fixed left distance
- adds text align center to the button's parent


## Any Screenshots of Your Changes :camera:
 
<img width="1633" alt="Screenshot 2019-10-24 at 20 50 04" src="https://user-images.githubusercontent.com/5271528/67520620-1987ab80-f6a1-11e9-9eaf-32a7490ca960.png">
<img width="1187" alt="Screenshot 2019-10-24 at 20 50 09" src="https://user-images.githubusercontent.com/5271528/67520627-1b516f00-f6a1-11e9-97ff-c2c528843009.png">
<img width="947" alt="Screenshot 2019-10-24 at 20 50 16" src="https://user-images.githubusercontent.com/5271528/67520631-1db3c900-f6a1-11e9-8039-502072f45fd8.png">
<img width="491" alt="Screenshot 2019-10-24 at 20 50 22" src="https://user-images.githubusercontent.com/5271528/67520639-20162300-f6a1-11e9-8e2e-cdc10dafb9c2.png">

